### PR TITLE
Make mudskipper not a singleton.

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,60 +2,66 @@ var Hoek = require('hoek');
 var Inflection = require('inflection');
 
 // Defaults for the methods
-var internals = {
-    hypermedia: {},
-    routes: [],
-    resources: {},
-    dependencies: {},
-    options: {},
-    namespace: '',
-    defaults: {
-        index: {
-            method: 'get',
-            config: {
-                bind: {}
-            }
-        },
-        show: {
-            method: 'get',
-            config: {
-                bind: {}
-            }
-        },
-        create: {
-            method: 'post',
-            config: {
-                bind: {}
-            }
-        },
-        update: {
-            method: 'put',
-            config: {
-                bind: {}
-            }
-        },
-        patch: {
-            method: 'patch',
-            config: {
-                bind: {}
-            }
-        },
-        destroy: {
-            method: 'delete',
-            config: {
-                bind: {}
+function Mudskipper(options) {
+    this.makeRoutes = options.makeRoutes || function () {
+        throw new Error("makeRoutes not defined in mudskipper config");
+    };
+
+    this.internals = {
+        hypermedia: {},
+        routes: [],
+        resources: {},
+        dependencies: {},
+        options: {},
+        namespace: '',
+        defaults: {
+            index: {
+                method: 'get',
+                config: {
+                    bind: {}
+                }
+            },
+            show: {
+                method: 'get',
+                config: {
+                    bind: {}
+                }
+            },
+            create: {
+                method: 'post',
+                config: {
+                    bind: {}
+                }
+            },
+            update: {
+                method: 'put',
+                config: {
+                    bind: {}
+                }
+            },
+            patch: {
+                method: 'patch',
+                config: {
+                    bind: {}
+                }
+            },
+            destroy: {
+                method: 'delete',
+                config: {
+                    bind: {}
+                }
             }
         }
-    }
-};
+    };
+}
 
 // a helper function to recurse through all the resources
 // and save their dependencies so we can find children later
-function saveDependencies(name, obj) {
+Mudskipper.prototype.saveDependencies = function _saveDependencies(name, obj) {
     var child, childName;
-    internals.dependencies[name] = { hasOne: [], hasMany: [] };
+    this.internals.dependencies[name] = { hasOne: [], hasMany: [] };
 
-    function _parse(prop) {
+    var parse = function _parse(prop) {
         if (!Array.isArray(obj[prop])) obj[prop] = [obj[prop]];
         for (var i = 0, l = obj[prop].length; i < l; i++) {
             child = obj[prop][i];
@@ -63,21 +69,21 @@ function saveDependencies(name, obj) {
                 Hoek.assert(Object.keys(child).length === 1, 'Child object must contain only one property');
 
                 childName = Object.keys(child)[0];
-                internals.dependencies[name][prop].push(childName);
-                internals.resources[childName] = child[childName];
-                internals.resources[childName].childOnly = true;
-                saveDependencies(childName, child[childName]);
-                delete internals.resources[childName].hasOne;
-                delete internals.resources[childName].hasMany;
+                this.internals.dependencies[name][prop].push(childName);
+                this.internals.resources[childName] = child[childName];
+                this.internals.resources[childName].childOnly = true;
+                this.saveDependencies(childName, child[childName]);
+                delete this.internals.resources[childName].hasOne;
+                delete this.internals.resources[childName].hasMany;
             } else {
-                internals.dependencies[name][prop].push(obj[prop][i]);
+                this.internals.dependencies[name][prop].push(obj[prop][i]);
             }
         }
-    }
+    }.bind(this);
 
-    if (obj.hasOne) _parse('hasOne');
-    if (obj.hasMany) _parse('hasMany');
-}
+    if (obj.hasOne) parse('hasOne');
+    if (obj.hasMany) parse('hasMany');
+};
 
 // the first pass goes through all keys, and makes sure that the hasOne
 // and hasMany properties are arrays of strings. if objects are found,
@@ -85,57 +91,57 @@ function saveDependencies(name, obj) {
 // to true, so as to prevent a top level route being created for them.
 // all other objects are copied to internals.resources with the hasOne
 // and hasMany keys removed.
-function firstPass() {
+Mudskipper.prototype.firstPass = function _firstPass() {
     var key, resource, child, childName, i, l;
 
-    for (key in internals.options) {
-        resource = internals.options[key];
-        internals.dependencies[key] = {};
-        saveDependencies(key, resource);
-        internals.resources[key] = resource;
-        delete internals.resources[key].hasOne;
-        delete internals.resources[key].hasMany;
+    for (key in this.internals.options) {
+        resource = this.internals.options[key];
+        this.internals.dependencies[key] = {};
+        this.saveDependencies(key, resource);
+        this.internals.resources[key] = resource;
+        delete this.internals.resources[key].hasOne;
+        delete this.internals.resources[key].hasMany;
     }
 
-    secondPass();
-}
+    this.secondPass();
+};
 
 // the second pass generates routes for all resources that
 // have top level routes (i.e. the childOnly flag is *not* set)
 // additionally, it ensures that methods for all resources are
 // an object containing a handler property set to a function
-function secondPass() {
+Mudskipper.prototype.secondPass = function _secondPass() {
     var key, resource, method, settings, objectPath, children, hasOneKeys, hasManyKeys, hypermedia;
 
-    for (key in internals.resources) {
-        resource = internals.resources[key];
-        hypermedia = generateHypermedia(key, [], false);
+    for (key in this.internals.resources) {
+        resource = this.internals.resources[key];
+        hypermedia = this.generateHypermedia(key, [], false);
 
         if (key === 'root') {
             if (typeof resource === 'function') resource = { handler: resource };
-            settings = Hoek.applyToDefaults(internals.defaults.index, resource);
-            settings.path = '/' + (internals.namespace ? internals.namespace : '');
+            settings = Hoek.applyToDefaults(this.internals.defaults.index, resource);
+            settings.path = '/' + (this.internals.namespace ? this.internals.namespace : '');
             settings.config.bind.hypermedia = hypermedia.collection;
             delete settings.collectionLinks;
             delete settings.itemLinks;
-            internals.routes.push(settings);
+            this.internals.routes.push(settings);
             continue;
         }
 
         if (resource.childOnly) continue;
-        children = findChildren(key);
+        children = this.findChildren(key);
         hasOneKeys = Object.keys(children.hasOne);
         hasManyKeys = Object.keys(children.hasMany);
-        objectPath = generateRoute(key, 'show', false, []);
+        objectPath = this.generateRoute(key, 'show', false, []);
 
         for (method in resource) {
             if (['index', 'create', 'show', 'update', 'patch', 'destroy'].indexOf(method) === -1) continue;
 
             if (typeof resource[method] === 'function') resource[method] = { handler: resource[method] };
 
-            settings = Hoek.applyToDefaults(internals.defaults[method], resource[method]);
+            settings = Hoek.applyToDefaults(this.internals.defaults[method], resource[method]);
             if (settings.config && settings.config.validate && settings.config.validate.path) delete settings.config.validate.path;
-            settings.path = '/' + generateRoute(key, method, false, []).join('/');
+            settings.path = '/' + this.generateRoute(key, method, false, []).join('/');
             if (method === 'index') {
                 settings.config.bind.hypermedia = hypermedia.collection;
             } else if (method === 'show') {
@@ -143,43 +149,43 @@ function secondPass() {
             }
             delete settings.itemLinks;
             delete settings.collectionLinks;
-            internals.routes.push(settings);
+            this.internals.routes.push(settings);
         }
 
         if (hasOneKeys.length) {
-            addChild(resource, objectPath, children.hasOne, true);
+            this.addChild(resource, objectPath, children.hasOne, true);
         }
 
         if (hasManyKeys.length) {
-            addChild(resource, objectPath, children.hasMany, false);
+            this.addChild(resource, objectPath, children.hasMany, false);
         }
     }
 
-    internals.plugin.route(internals.routes);
+    this.makeRoutes(this.internals.routes);
 
-    // reset internals
-    internals.hypermedia = {};
-    internals.routes = [];
-    internals.resources = {};
-    internals.dependencies = {};
-    internals.options = {};
-    internals.namespace = '';
-}
+    // reset this.internals
+    this.internals.hypermedia = {};
+    this.internals.routes = [];
+    this.internals.resources = {};
+    this.internals.dependencies = {};
+    this.internals.options = {};
+    this.internals.namespace = '';
+};
 
 // a helper function to recursively find children from a given parent
-function findChildren(parent, children, parents) {
+Mudskipper.prototype.findChildren = function _findChildren(parent, children, parents) {
     children = children || { hasOne: {}, hasMany: {} };
     parents = parents || [parent];
     if (!children.hasOne[parent] && !children.hasMany[parent]) children.hasOne[parent] = { hasOne: {}, hasMany: {} };
-    var deps = internals.dependencies[parent];
+    var deps = this.internals.dependencies[parent];
     var child;
 
-    function addChildren(prop) {
+    var addChildren = function _addChildren(prop) {
         for (var i = 0, l = deps[prop].length; i < l; i++) {
             if (parents.indexOf(deps[prop][i]) !== -1) continue;
-            children[prop][deps[prop][i]] = findChildren(deps[prop][i], children[prop][parent], parents.concat([deps[prop][i]]));
+            children[prop][deps[prop][i]] = this.findChildren(deps[prop][i], children[prop][parent], parents.concat([deps[prop][i]]));
         }
-    }
+    }.bind(this);
 
     if (deps) {
         if (deps.hasOne) addChildren('hasOne');
@@ -189,16 +195,16 @@ function findChildren(parent, children, parents) {
     delete children.hasOne[parent];
 
     return children;
-}
+};
 
-function generateHypermedia(name, path, singular, parent) {
-    var resource = internals.resources[name];
+Mudskipper.prototype.generateHypermedia = function _generateHypermedia(name, path, singular, parent) {
+    var resource = this.internals.resources[name];
     var hypermedia = {};
     var newpath;
 
     if (name === 'root') {
-        if (internals.namespace) {
-            newpath = '/' + internals.namespace;
+        if (this.internals.namespace) {
+            newpath = '/' + this.internals.namespace;
         } else {
             newpath = '/';
         }
@@ -209,39 +215,39 @@ function generateHypermedia(name, path, singular, parent) {
             items: {}
         };
 
-        Object.keys(internals.resources).forEach(function (key) {
-            if (internals.resources[key].childOnly || key === 'root') return;
-            if (internals.resources[key].path) {
-                newpath = internals.resources[key].path;
-                if (internals.resources[key].path[0] === '/') {
+        Object.keys(this.internals.resources).forEach(function (key) {
+            if (this.internals.resources[key].childOnly || key === 'root') return;
+            if (this.internals.resources[key].path) {
+                newpath = this.internals.resources[key].path;
+                if (this.internals.resources[key].path[0] === '/') {
                     hypermedia.collection.links[key] = { href: newpath };
                 } else {
-                    if (internals.namespace) {
-                        newpath = '/' + internals.namespace + '/' + newpath;
+                    if (this.internals.namespace) {
+                        newpath = '/' + this.internals.namespace + '/' + newpath;
                     }
                     hypermedia.collection.links[key] = { href: newpath };
                 }
             } else {
                 newpath = '/' + key;
-                if (internals.namespace) {
-                    newpath = '/' + internals.namespace + newpath;
+                if (this.internals.namespace) {
+                    newpath = '/' + this.internals.namespace + newpath;
                 }
                 hypermedia.collection.links[key] = { href: newpath };
             }
-        });
+        }.bind(this));
         if (resource.collectionLinks) hypermedia.collection.links = Hoek.merge(hypermedia.collection.links, resource.collectionLinks);
         return hypermedia;
     }
 
-    var hasOne = internals.dependencies[name].hasOne;
-    var hasMany = internals.dependencies[name].hasMany;
-    var rootPath = '/' + generateRoute(name, 'index', singular, path).join('/');
-    var itemPath = '/' + generateRoute(name, 'show', singular, path).join('/');
+    var hasOne = this.internals.dependencies[name].hasOne;
+    var hasMany = this.internals.dependencies[name].hasMany;
+    var rootPath = '/' + this.generateRoute(name, 'index', singular, path).join('/');
+    var itemPath = '/' + this.generateRoute(name, 'show', singular, path).join('/');
     var href, methods, upPath, singularParent;
 
     if (!parent) {
-        if (internals.namespace) {
-            upPath = '/' + internals.namespace;
+        if (this.internals.namespace) {
+            upPath = '/' + this.internals.namespace;
         } else {
             upPath = '/';
         }
@@ -295,14 +301,14 @@ function generateHypermedia(name, path, singular, parent) {
             return path.indexOf(key) === -1 && path.indexOf(Inflection.singularize(key)) === -1;
         });
         hasOne.forEach(function (key) {
-            href = '/' + generateRoute(key, 'show', true, itemPath.slice(1).split('/')).join('/');
+            href = '/' + this.generateRoute(key, 'show', true, itemPath.slice(1).split('/')).join('/');
             methods = [];
-            if (internals.resources[key].show) methods.push('get');
-            if (internals.resources[key].update) methods.push('put');
-            if (internals.resources[key].patch) methods.push('patch');
-            if (internals.resources[key].destroy) methods.push('delete');
+            if (this.internals.resources[key].show) methods.push('get');
+            if (this.internals.resources[key].update) methods.push('put');
+            if (this.internals.resources[key].patch) methods.push('patch');
+            if (this.internals.resources[key].destroy) methods.push('delete');
             hypermedia.item.items[Inflection.singularize(key)] = { href: href, methods: methods };
-        });
+        }.bind(this));
     }
 
     if (hasMany.length) {
@@ -310,25 +316,25 @@ function generateHypermedia(name, path, singular, parent) {
             return path.indexOf(key) === -1 && path.indexOf(Inflection.singularize(key)) === -1;
         });
         hasMany.forEach(function (key) {
-            href = '/' + generateRoute(key, 'index', false, itemPath.slice(1).split('/')).join('/');
+            href = '/' + this.generateRoute(key, 'index', false, itemPath.slice(1).split('/')).join('/');
             methods = [];
-            if (internals.resources[key].index) methods.push('get');
-            if (internals.resources[key].create) methods.push('post');
+            if (this.internals.resources[key].index) methods.push('get');
+            if (this.internals.resources[key].create) methods.push('post');
             hypermedia.item.items[key] = { href: href, methods: methods };
-        });
+        }.bind(this));
     }
 
     return hypermedia;
-}
+};
 
-function generateRoute(name, method, singular, path) {
+Mudskipper.prototype.generateRoute = function _generateRoute(name, method, singular, path) {
     var segments;
 
     if (path.length) {
         segments = [].concat(path);
     } else {
-        if (internals.namespace && (!internals.resources[name].path || internals.resources[name].path[0] !== '/')) {
-            segments = [internals.namespace];
+        if (this.internals.namespace && (!this.internals.resources[name].path || this.internals.resources[name].path[0] !== '/')) {
+            segments = [this.internals.namespace];
         } else {
             segments = [];
         }
@@ -340,15 +346,15 @@ function generateRoute(name, method, singular, path) {
         nextSegment = Inflection.singularize(name);
     }
 
-    if (internals.resources[name].path) {
-        if (internals.resources[name].path[0] === '/') {
+    if (this.internals.resources[name].path) {
+        if (this.internals.resources[name].path[0] === '/') {
             if (method === 'index' || method === 'create') {
-                return internals.resources[name].path.slice(1).split('/');
+                return this.internals.resources[name].path.slice(1).split('/');
             } else {
-                nextSegment = internals.resources[name].path.slice(1).split('/');
+                nextSegment = this.internals.resources[name].path.slice(1).split('/');
             }
         } else {
-            nextSegment = internals.resources[name].path.split('/');
+            nextSegment = this.internals.resources[name].path.split('/');
         }
         segments = segments.concat(nextSegment);
     } else {
@@ -356,7 +362,7 @@ function generateRoute(name, method, singular, path) {
     }
 
     nextSegment = '';
-    if (internals.uniqueIds === false) {
+    if (this.internals.uniqueIds === false) {
         if (path.length) {
             path.forEach(function (p) {
                 if (p.charAt(0) === '{') {
@@ -374,9 +380,9 @@ function generateRoute(name, method, singular, path) {
     }
 
     return segments;
-}
+};
 
-function addChild(parent, path, child, singular) {
+Mudskipper.prototype.addChild = function _addChild(parent, path, child, singular) {
     var i, l, childName, settings, method, objectPath, route, hasOneKeys, hasManyKeys, hypermedia;
 
     function stripHandlers(obj) {
@@ -393,23 +399,23 @@ function addChild(parent, path, child, singular) {
         childName = Object.keys(child)[i];
         hasOneKeys = Object.keys(child[childName].hasOne);
         hasManyKeys = Object.keys(child[childName].hasMany);
-        objectPath = generateRoute(childName, 'show', singular, path);
-        hypermedia = generateHypermedia(childName, path, singular, parent);
+        objectPath = this.generateRoute(childName, 'show', singular, path);
+        hypermedia = this.generateHypermedia(childName, path, singular, parent);
 
-        for (method in internals.resources[childName]) {
+        for (method in this.internals.resources[childName]) {
             if (!singular) {
                 if (['index', 'create', 'show', 'update', 'patch', 'destroy'].indexOf(method) === -1) continue;
             } else {
                 if (['show', 'update', 'patch', 'destroy'].indexOf(method) === -1) continue;
             }
 
-            if (typeof internals.resources[childName][method] === 'function') internals.resources[childName][method] = { handler: internals.resources[childName][method] };
-            settings = parent && parent[method] ? Hoek.merge(parent[method], internals.resources[childName][method]) : internals.resources[childName][method];
+            if (typeof this.internals.resources[childName][method] === 'function') this.internals.resources[childName][method] = { handler: this.internals.resources[childName][method] };
+            settings = parent && parent[method] ? Hoek.merge(parent[method], this.internals.resources[childName][method]) : this.internals.resources[childName][method];
             if (settings.config && settings.config.validate && settings.config.validate.path) delete settings.config.validate.path;
 
-            route = Hoek.applyToDefaults(internals.defaults[method], settings);
+            route = Hoek.applyToDefaults(this.internals.defaults[method], settings);
 
-            route.path = '/' + generateRoute(childName, method, singular, path).join('/');
+            route.path = '/' + this.generateRoute(childName, method, singular, path).join('/');
             if (method === 'index') {
                 route.config.bind.hypermedia = hypermedia.collection;
             } else if (method === 'show') {
@@ -417,30 +423,34 @@ function addChild(parent, path, child, singular) {
             }
             delete route.itemLinks;
             delete route.collectionLinks;
-            internals.routes.push(route);
+            this.internals.routes.push(route);
         }
 
-        if (hasOneKeys.length) addChild(settings, objectPath, child[childName].hasOne, true);
-        if (hasManyKeys.length) addChild(settings, objectPath, child[childName].hasMany, false);
+        if (hasOneKeys.length) this.addChild(settings, objectPath, child[childName].hasOne, true);
+        if (hasManyKeys.length) this.addChild(settings, objectPath, child[childName].hasMany, false);
     }
-}
+};
 
-function buildRoutes(options, next) {
+Mudskipper.prototype.buildRoutes = function _buildRoutes(options, next) {
     Hoek.assert(typeof options === 'object', 'Options must be defined as an object');
     Hoek.assert(options.hasOwnProperty('namespace') ? typeof options.namespace === 'string' : true, 'Namespace must be a string');
 
-    internals.options = options.resources;
-    internals.uniqueIds = options.hasOwnProperty('uniqueIds') ? options.uniqueIds : true;
-    internals.namespace = options.hasOwnProperty('namespace') ? options.namespace : '';
-    if (Object.keys(internals.options).length) {
-        firstPass();
+    this.internals.options = options.resources;
+    this.internals.uniqueIds = options.hasOwnProperty('uniqueIds') ? options.uniqueIds : true;
+    this.internals.namespace = options.hasOwnProperty('namespace') ? options.namespace : '';
+    if (Object.keys(this.internals.options).length) {
+        this.firstPass();
     }
     next();
-}
+};
 
-exports.register = function (plugin, options, next) {
-    internals.plugin = plugin;
+module.exports = Mudskipper;
+module.exports.register = function (plugin, options, next) {
+    var mudskipper = new Mudskipper({
+        makeRoutes: plugin.route.bind(plugin)
+    });
+
     options.resources = options.resources || {};
-    plugin.expose({ route: buildRoutes });
-    buildRoutes(options, next);
+    plugin.expose({ route: mudskipper.buildRoutes.bind(mudskipper) });
+    mudskipper.buildRoutes(options, next);
 };


### PR DESCRIPTION
- This means that when hapi supports multiple instances of the same plugin mudskipper will work.
- This also allows you to access Mudskipper directly, so that you can instantiate the module multiple times independently (not as a plugin) without hapi complaining.

example usage standalone in another hapi plugin:

```javascript
var Mudskipper = require('mudskipper');

exports.register = function (plugin, options, next) {
    plugin.loader(require);
    var mudskipper = new Mudskipper({
        makeRoutes: plugin.route.bind(plugin)
    });

    mudskipper.buildRoutes({
        resources: {
            users: {
                index: function (request, reply) {
                    reply([{ name: 'plugin1' }]);
                }
            }
        }
    }, next);
};
```

I made this as straightforward a port as possible. It could probably be tidied up quite a bit, but didn't want to confuse the reorganisation so we can check we're happy with it before we clean it up.
