### PR TITLE
Fix config getting merged across hasOne/hasMany subroutes

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,37 +18,31 @@ var Mudskipper = function (options) {
             index: {
                 method: 'get',
                 config: {
-                    bind: {}
                 }
             },
             show: {
                 method: 'get',
                 config: {
-                    bind: {}
                 }
             },
             create: {
                 method: 'post',
                 config: {
-                    bind: {}
                 }
             },
             update: {
                 method: 'put',
                 config: {
-                    bind: {}
                 }
             },
             patch: {
                 method: 'patch',
                 config: {
-                    bind: {}
                 }
             },
             destroy: {
                 method: 'delete',
                 config: {
-                    bind: {}
                 }
             }
         }


### PR DESCRIPTION
Not super excited about my tests for this, seemed a bit weird to add a whole other set of data just for one test, but I figured I'd commit anyway and we can discuss.

Basically because merge instead of applyDefaults was being used, if you had multiple hasOne configs on a route, the first one's config got merged up into the parent, and the second then inherited the config of the first.
